### PR TITLE
Add localizedValue method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,14 @@
 *.so*
 Makefile
 *.pro.user
-.moc
-.obj
+*.moc
+*.list
+ut_*
+moc_*
 mnotificationmanagerproxy.*
-tools/mlitenotificationtool/mlitenotificationtool
+/src/mlite5.pc
+/tests/Makefile.ut_*
+/tests/tests.xml
+/tools/mlitenotificationtool/mlitenotificationtool
+/tools/mliteremoteaction/mliteremoteaction
+/RPMS/

--- a/src/mdesktopentry.h
+++ b/src/mdesktopentry.h
@@ -5,7 +5,7 @@
 ** Copyright (C) 2010, 2011 Nokia Corporation and/or its subsidiary(-ies).
 ** Copyright (C) 2011 Intel Corp.
 ** Copyright (C) 2012, 2013 Jolla Ltd.
-** Copyright (C) 2020 Open Mobile Platform LLC.
+** Copyright (C) 2020 - 2021 Open Mobile Platform LLC.
 **
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
@@ -254,6 +254,18 @@ public:
      * Returns whether the application is sandboxed.
      */
     bool isSandboxed() const;
+
+    /*!
+     * Returns the localized value of the key or an empty string if it is
+     * not defined in the input desktop entry file.
+     */
+    QString localizedValue(const QString &key) const;
+
+    /*!
+     * Returns the localized value of the group-key stored as "group/key"
+     * key or an empty string if it is not defined in the input desktop entry file.
+     */
+    QString localizedValue(const QString &group, const QString &key) const;
 
 protected:
     /*! \internal */

--- a/src/mdesktopentry_p.h
+++ b/src/mdesktopentry_p.h
@@ -4,7 +4,8 @@
 **
 ** Copyright (C) 2010, 2011 Nokia Corporation and/or its subsidiary(-ies).
 ** Copyright (C) 2011 Intel Corp.
-** Copyright (C) 2012, 2013 Jolla Ltd.
+** Copyright (C) 2012 - 2014 Jolla Ltd.
+** Copyright (C) 2020 - 2021 Open Mobile Platfrom LLC.
 **
 ** This library is free software; you can redistribute it and/or
 ** modify it under the terms of the GNU Lesser General Public
@@ -96,10 +97,19 @@ public:
     mutable QString translatedName;
 
     /*!
-     * Loads a QTranslator from X-MeeGo-Translation-Catalog
+     * Loads QTranslator from X-Amber/MeeGo-Translation-Catalog
      * \return A translator for specified catalog, or null
      */
     QTranslator *loadTranslator() const;
+
+    //! Translator cache, limits how long it can live
+    mutable QScopedPointer<QTimer> translatorCacheTimer;
+
+    //! Cached translator
+    mutable QScopedPointer<QTranslator> cachedTranslator;
+
+    //! Translator is unavailable, don't try to load again
+    mutable bool translatorUnavailable;
 
 protected:
     /*


### PR DESCRIPTION
This allows fetching any key with a localized value.

Instead of using a specific for Name translation, add a template that
can be used for any key's translation id. Also remove some MeeGo legacy
by introducing Amber name for translation catalog.

As translator can be now used multiple times but it's unlikely to be
used after a longer period of time, thus a pointer to it is stored and
the instance is destroyed with a timer after a while. If translations
are needed later again, the translator is constructed again.