### PR TITLE
MRemoteAction enhancements. JB#60924

### DIFF
--- a/src/mremoteaction.cpp
+++ b/src/mremoteaction.cpp
@@ -86,9 +86,10 @@ QString MRemoteActionPrivate::toString() const
     return s;
 }
 
-MRemoteAction::MRemoteAction(const QString &serviceName, const QString &objectPath, const QString &interface, const QString &methodName, const QList<QVariant> &arguments, QObject *parent) :
-    QObject(parent),
-    d_ptr(new MRemoteActionPrivate)
+MRemoteAction::MRemoteAction(const QString &serviceName, const QString &objectPath, const QString &interface,
+                             const QString &methodName, const QList<QVariant> &arguments, QObject *parent)
+    : QObject(parent)
+    , d_ptr(new MRemoteActionPrivate)
 {
     Q_D(MRemoteAction);
 
@@ -99,9 +100,9 @@ MRemoteAction::MRemoteAction(const QString &serviceName, const QString &objectPa
     d->arguments = arguments;
 }
 
-MRemoteAction::MRemoteAction(const QString &string, QObject *parent) :
-    QObject(parent),
-    d_ptr(new MRemoteActionPrivate)
+MRemoteAction::MRemoteAction(const QString &string, QObject *parent)
+    : QObject(parent)
+    , d_ptr(new MRemoteActionPrivate)
 {
     fromString(string);
 }
@@ -144,9 +145,9 @@ void MRemoteAction::fromString(const QString &string)
     }
 }
 
-MRemoteAction::MRemoteAction(const MRemoteAction &action) :
-    QObject(action.parent()),
-    d_ptr(new MRemoteActionPrivate)
+MRemoteAction::MRemoteAction(const MRemoteAction &action)
+    : QObject(action.parent())
+    , d_ptr(new MRemoteActionPrivate)
 {
     fromString(action.toString());
 }
@@ -188,6 +189,30 @@ QVariantList MRemoteAction::arguments() const
 {
     Q_D(const MRemoteAction);
     return d->arguments;
+}
+
+void MRemoteAction::setServiceName(const QString &service)
+{
+    Q_D(MRemoteAction);
+    d->serviceName = service;
+}
+
+void MRemoteAction::setObjectPath(const QString &path)
+{
+    Q_D(MRemoteAction);
+    d->objectPath = path;
+}
+
+void MRemoteAction::setInterface(const QString &interface)
+{
+    Q_D(MRemoteAction);
+    d->interface = interface;
+}
+
+void MRemoteAction::setArguments(const QVariantList &arguments)
+{
+    Q_D(MRemoteAction);
+    d->arguments = arguments;
 }
 
 void MRemoteAction::trigger()

--- a/src/mremoteaction.cpp
+++ b/src/mremoteaction.cpp
@@ -49,7 +49,7 @@ void MRemoteActionPrivate::trigger(bool wait)
     const int euid = geteuid();
     const int egid = getegid();
 
-    if (uid != euid || gid != egid) {
+    if (!keepPrivileges && (uid != euid || gid != egid)) {
         QProcess::startDetached(QStringLiteral("/usr/libexec/mliteremoteaction"), { toString() });
         return;
     }
@@ -147,9 +147,8 @@ void MRemoteAction::fromString(const QString &string)
 
 MRemoteAction::MRemoteAction(const MRemoteAction &action)
     : QObject(action.parent())
-    , d_ptr(new MRemoteActionPrivate)
+    , d_ptr(new MRemoteActionPrivate(*action.d_ptr))
 {
-    fromString(action.toString());
 }
 
 bool MRemoteAction::isValid() const
@@ -213,6 +212,18 @@ void MRemoteAction::setArguments(const QVariantList &arguments)
 {
     Q_D(MRemoteAction);
     d->arguments = arguments;
+}
+
+bool MRemoteAction::keepPrivileges() const
+{
+    Q_D(const MRemoteAction);
+    return d->keepPrivileges;
+}
+
+void MRemoteAction::setKeepPrivileges(bool keep)
+{
+    Q_D(MRemoteAction);
+    d->keepPrivileges = keep;
 }
 
 void MRemoteAction::trigger()

--- a/src/mremoteaction.h
+++ b/src/mremoteaction.h
@@ -47,7 +47,9 @@ public:
      * \param arguments the arguments of the D-Bus call. Defaults to no arguments.
      * \param parent Parent object
      */
-    explicit MRemoteAction(const QString &serviceName, const QString &objectPath, const QString &interface, const QString &methodName, const QList<QVariant> &arguments = QList<QVariant>(), QObject *parent = NULL);
+    explicit MRemoteAction(const QString &serviceName, const QString &objectPath, const QString &interface,
+                           const QString &methodName, const QList<QVariant> &arguments = QList<QVariant>(),
+                           QObject *parent = NULL);
 
     /*!
      * \brief Constructs a MRemoteAction from a string representation of a D-Bus remote action acquired with toString().
@@ -112,6 +114,26 @@ public:
      * \return a list of arguments.
      */
     QVariantList arguments() const;
+
+    /*!
+     * \brief Sets the service name of the D-Bus method to call.
+     */
+    void setServiceName(const QString &service);
+
+    /*!
+     * \brief Sets the object path of the D-Bus method to call.
+     */
+    void setObjectPath(const QString &path);
+
+    /*!
+     * \brief Sets the interface of the D-Bus method to call.
+     */
+    void setInterface(const QString &interface);
+
+    /*!
+     * \brief Sets the arguments of the D-Bus method to call.
+     */
+    void setArguments(const QVariantList &arguments);
 
 public Q_SLOTS:
     /*!

--- a/src/mremoteaction.h
+++ b/src/mremoteaction.h
@@ -135,6 +135,16 @@ public:
      */
     void setArguments(const QVariantList &arguments);
 
+    /*!
+     * \brief Returns whether D-Bus method is called without dropping extra privileges
+     */
+    bool keepPrivileges() const;
+
+    /*!
+     * \brief Sets whether D-Bus method is called without dropping extra privileges
+     */
+    void setKeepPrivileges(bool keep);
+
 public Q_SLOTS:
     /*!
      * \brief A slot for calling the D-Bus function when the action is triggered

--- a/src/mremoteaction_p.h
+++ b/src/mremoteaction_p.h
@@ -26,12 +26,8 @@
 #include <QVariant>
 #include <QVector>
 
-class MRemoteAction;
-
 class MRemoteActionPrivate
 {
-    Q_DECLARE_PUBLIC(MRemoteAction)
-
 public:
     MRemoteActionPrivate();
     virtual ~MRemoteActionPrivate();
@@ -49,9 +45,7 @@ public:
     QString methodName;
     //! The arguments of the D-Bus call
     QList<QVariant> arguments;
-
-protected:
-    MRemoteAction *q_ptr;
+    bool keepPrivileges = false;
 };
 
 #endif

--- a/tests/ut_mremoteaction.cpp
+++ b/tests/ut_mremoteaction.cpp
@@ -25,6 +25,7 @@ private slots:
     void initTestCase();
     void serialization();
     void trigger();
+    void copy();
 };
 
 class UtMRemoteAction::ServiceMock : public DBusClientTestBase::MockBase
@@ -100,6 +101,19 @@ void UtMRemoteAction::trigger()
     QCOMPARE(spy[0][0].toInt(), 123);
     QCOMPARE(spy[0][1].toString(), QString("abc"));
     QCOMPARE(spy[0][2].toStringList(), QStringList() << "a" << "b" << "c");
+}
+
+void UtMRemoteAction::copy()
+{
+    MRemoteAction action(SERVICE_NAME, OBJECT_PATH, INTERFACE, "Baz",
+            QList<QVariant>()
+            << 123
+            << "abc"
+            << (QStringList() << "a" << "b" << "c"));
+    QVERIFY(!action.keepPrivileges()); // no privileges by default
+    QVERIFY(!MRemoteAction(action).keepPrivileges()); // neither on a copy
+    action.setKeepPrivileges(true);
+    QVERIFY(MRemoteAction(action).keepPrivileges()); // also this gets copied
 }
 
 TEST_MAIN_WITH_MOCK(UtMRemoteAction, UtMRemoteAction::ServiceMock)


### PR DESCRIPTION
Allows to modify MRemoteAction properties after instantiation.
Allows to explicitly make the d-bus call keep the privileges of the calling process. 