### PR TITLE
[mlite] Fix build on Qt5.12

### DIFF
--- a/src/mpermission.cpp
+++ b/src/mpermission.cpp
@@ -33,7 +33,7 @@ const auto TranslationSeparator = QStringLiteral("-");
 const auto SailjailSection = QStringLiteral("X-Sailjail");
 const auto SailjailPermissionsKey = QStringLiteral("Permissions");
 
-#if (QT_VERSION < QT_VERSION_CHECK(5, 10, 0))
+#if (QT_VERSION < QT_VERSION_CHECK(5, 14, 0))
 QPair<QStringRef, QStringRef> getField(const QString &line)
 {
     QStringRef remaining = line.midRef(0).trimmed();


### PR DESCRIPTION
QStringView's indexOf method etc were only introduced with 5.14.
https://doc.qt.io/qt-5/qstringview.html#indexOf
https://github.com/qt/qtbase/blob/5.12/src/corelib/tools/qstringview.h
https://github.com/qt/qtbase/blob/5.14/src/corelib/text/qstringview.h
```
mpermission.cpp: In function ‘QPair<QStringView, QStringView> {anonymous}::getField(const QString&)’:
mpermission.cpp:68:31: error: ‘class QStringView’ has no member named ‘indexOf’
   68 |     int separator = remaining.indexOf('=');
      |                               ^~~~~~~
In file included from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhashfunctions.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qlist.h:47,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhash.h:46,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qdebug.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/QDebug:1,
                 from mpermission.cpp:12:
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qpair.h: In instantiation of ‘constexpr QPair<T1, T2>::QPair(QPair<TT1, TT2>&&) [with TT1 = QStringView; TT2 = QStringView; T1 = QStringRef; T2 = QStringRef]’:
mpermission.cpp:109:60:   required from here
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qpair.h:80:84: error: no matching function for call to ‘QStringRef::QStringRef(QStringView)’
   80 |         : first(static_cast<TT1 &&>(p.first)), second(static_cast<TT2 &&>(p.second)) {}
      |                                                                                    ^
In file included from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhashfunctions.h:44,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qlist.h:47,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhash.h:46,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qdebug.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/QDebug:1,
                 from mpermission.cpp:12:
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1446:5: note: candidate: ‘QStringRef::QStringRef(QStringRef&&)’
 1446 |     QStringRef(QStringRef &&other) Q_DECL_NOTHROW : m_string(other.m_string), m_position(other.m_position), m_size(other.m_size) {}
      |     ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1446:29: note:   no known conversion for argument 1 from ‘QStringView’ to ‘QStringRef&&’
 1446 |     QStringRef(QStringRef &&other) Q_DECL_NOTHROW : m_string(other.m_string), m_position(other.m_position), m_size(other.m_size) {}
      |                ~~~~~~~~~~~~~^~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1442:5: note: candidate: ‘QStringRef::QStringRef(const QStringRef&)’
 1442 |     QStringRef(const QStringRef &other) Q_DECL_NOTHROW
      |     ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1442:34: note:   no known conversion for argument 1 from ‘QStringView’ to ‘const QStringRef&’
 1442 |     QStringRef(const QStringRef &other) Q_DECL_NOTHROW
      |                ~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1614:8: note: candidate: ‘QStringRef::QStringRef(const QString*)’
 1614 | inline QStringRef::QStringRef(const QString *aString)
      |        ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1614:46: note:   no known conversion for argument 1 from ‘QStringView’ to ‘const QString*’
 1614 | inline QStringRef::QStringRef(const QString *aString)
      |                               ~~~~~~~~~~~~~~~^~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1611:8: note: candidate: ‘QStringRef::QStringRef(const QString*, int, int)’
 1611 | inline QStringRef::QStringRef(const QString *aString, int aPosition, int aSize)
      |        ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1611:8: note:   candidate expects 3 arguments, 1 provided
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1436:12: note: candidate: ‘QStringRef::QStringRef()’
 1436 |     inline QStringRef() : m_string(nullptr), m_position(0), m_size(0) {}
      |            ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1436:12: note:   candidate expects 0 arguments, 1 provided
In file included from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhashfunctions.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qlist.h:47,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhash.h:46,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qdebug.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/QDebug:1,
                 from mpermission.cpp:12:
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qpair.h:80:84: error: no matching function for call to ‘QStringRef::QStringRef(QStringView)’
   80 |         : first(static_cast<TT1 &&>(p.first)), second(static_cast<TT2 &&>(p.second)) {}
      |                                                                                    ^
In file included from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhashfunctions.h:44,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qlist.h:47,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qhash.h:46,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/qdebug.h:45,
                 from /usr/include/arm-linux-gnueabihf/qt5/QtCore/QDebug:1,
                 from mpermission.cpp:12:
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1446:5: note: candidate: ‘QStringRef::QStringRef(QStringRef&&)’
 1446 |     QStringRef(QStringRef &&other) Q_DECL_NOTHROW : m_string(other.m_string), m_position(other.m_position), m_size(other.m_size) {}
      |     ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1446:29: note:   no known conversion for argument 1 from ‘QStringView’ to ‘QStringRef&&’
 1446 |     QStringRef(QStringRef &&other) Q_DECL_NOTHROW : m_string(other.m_string), m_position(other.m_position), m_size(other.m_size) {}
      |                ~~~~~~~~~~~~~^~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1442:5: note: candidate: ‘QStringRef::QStringRef(const QStringRef&)’
 1442 |     QStringRef(const QStringRef &other) Q_DECL_NOTHROW
      |     ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1442:34: note:   no known conversion for argument 1 from ‘QStringView’ to ‘const QStringRef&’
 1442 |     QStringRef(const QStringRef &other) Q_DECL_NOTHROW
      |                ~~~~~~~~~~~~~~~~~~^~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1614:8: note: candidate: ‘QStringRef::QStringRef(const QString*)’
 1614 | inline QStringRef::QStringRef(const QString *aString)
      |        ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1614:46: note:   no known conversion for argument 1 from ‘QStringView’ to ‘const QString*’
 1614 | inline QStringRef::QStringRef(const QString *aString)
      |                               ~~~~~~~~~~~~~~~^~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1611:8: note: candidate: ‘QStringRef::QStringRef(const QString*, int, int)’
 1611 | inline QStringRef::QStringRef(const QString *aString, int aPosition, int aSize)
      |        ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1611:8: note:   candidate expects 3 arguments, 1 provided
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1436:12: note: candidate: ‘QStringRef::QStringRef()’
 1436 |     inline QStringRef() : m_string(nullptr), m_position(0), m_size(0) {}
      |            ^~~~~~~~~~
/usr/include/arm-linux-gnueabihf/qt5/QtCore/qstring.h:1436:12: note:   candidate expects 0 arguments, 1 provided

```